### PR TITLE
Add keyboard input with audio feedback

### DIFF
--- a/Code/ACOS/pwm_sound.h
+++ b/Code/ACOS/pwm_sound.h
@@ -10,6 +10,7 @@
 #define AUDIO_PIN_L 26
 #define AUDIO_PIN_R 27
 
-void init_pwm(irq_handler_t);
+void init_pwm();
+void play_click();
 
 #endif //PWM_SOUND_H

--- a/Code/ACOS/pwm_sound.ino
+++ b/Code/ACOS/pwm_sound.ino
@@ -1,29 +1,19 @@
-
 #include "pwm_sound.h"
 
+static uint slice_l;
+static uint slice_r;
+static const uint16_t wrap_value = 1000;
 
-void init_pwm(irq_handler_t my_handler) {
-
+void init_pwm() {
     gpio_set_function(AUDIO_PIN_L, GPIO_FUNC_PWM);
     gpio_set_function(AUDIO_PIN_R, GPIO_FUNC_PWM);
 
-    int slice_l = pwm_gpio_to_slice_num(AUDIO_PIN_L);
-    int slice_r = pwm_gpio_to_slice_num(AUDIO_PIN_R);
-
-
-    pwm_clear_irq(slice_l);
-    pwm_clear_irq(slice_r);
-    pwm_set_irq_enabled(slice_l, true);
-    pwm_set_irq_enabled(slice_r, true);
-
-    irq_set_exclusive_handler(PWM_IRQ_WRAP, my_handler);
-    irq_set_enabled(PWM_IRQ_WRAP, true);
-
+    slice_l = pwm_gpio_to_slice_num(AUDIO_PIN_L);
+    slice_r = pwm_gpio_to_slice_num(AUDIO_PIN_R);
 
     pwm_config config = pwm_get_default_config();
-    pwm_config_set_clkdiv(&config, 6.05f); // 133MHz
-    pwm_config_set_wrap(&config, 250);
-
+    pwm_config_set_clkdiv(&config, 125.0f);
+    pwm_config_set_wrap(&config, wrap_value);
 
     pwm_init(slice_l, &config, true);
     pwm_init(slice_r, &config, true);
@@ -31,3 +21,12 @@ void init_pwm(irq_handler_t my_handler) {
     pwm_set_chan_level(slice_l, PWM_CHAN_A, 0);
     pwm_set_chan_level(slice_r, PWM_CHAN_B, 0);
 }
+
+void play_click() {
+    pwm_set_chan_level(slice_l, PWM_CHAN_A, wrap_value / 2);
+    pwm_set_chan_level(slice_r, PWM_CHAN_B, wrap_value / 2);
+    sleep_ms(10);
+    pwm_set_chan_level(slice_l, PWM_CHAN_A, 0);
+    pwm_set_chan_level(slice_r, PWM_CHAN_B, 0);
+}
+


### PR DESCRIPTION
## Summary
- Display initial "[ACOS]" banner and interactive prompt
- Add keyboard polling with character echoing and backspace/enter handling
- Enable PWM audio output with simple click feedback

## Testing
- `arduino-cli compile Code/ACOS --fqbn rp2040:rp2040:rpipico` *(failed: network is unreachable)*


------
https://chatgpt.com/codex/tasks/task_e_68a7d56443f083298a5e126b1859c304