### PR TITLE
Simulate modem dial and BBS login screen

### DIFF
--- a/Code/ACOS/ACOS.ino
+++ b/Code/ACOS/ACOS.ino
@@ -27,21 +27,16 @@ static int cursor_y = 0;
 static char input_buffer[64];
 static int input_length = 0;
 
+void simulate_modem_dial();
+void show_login_screen();
+
 void setup(void) {
 //  Serial.begin(115200);  
 
   tft.init();
 
-  tft.fillScreen(TFT_BLACK);
   tft.invertDisplay( true ); // Where i is true or false
-
   tft.setTextColor(TFT_WHITE);
-  int16_t w = tft.textWidth("[ACOS]");
-  tft.setCursor((SCREEN_WIDTH - w) / 2, 0);
-  tft.println("[ACOS]");
-  tft.print("> ");
-  cursor_x = tft.getCursorX();
-  cursor_y = tft.getCursorY();
 
   gpio_init(LEDPIN);
   gpio_set_dir(LEDPIN,GPIO_OUT);
@@ -74,6 +69,36 @@ void setup(void) {
 
   init_i2c_kbd();
   init_pwm();
+  simulate_modem_dial();
+}
+
+void simulate_modem_dial() {
+  tft.fillScreen(TFT_BLACK);
+  tft.setCursor(0, 0);
+  const char *dial = "ATDT5551212";
+  for (const char *p = dial; *p; ++p) {
+    tft.print(*p);
+    if (*p >= '0' && *p <= '9') {
+      play_dtmf_sequence(*p);
+    }
+    sleep_ms(150);
+  }
+  tft.println();
+  tft.println("CONNECT 9600");
+  play_modem_handshake();
+  sleep_ms(500);
+  show_login_screen();
+}
+
+void show_login_screen() {
+  tft.fillScreen(TFT_BLACK);
+  tft.setCursor(0, 0);
+  tft.println("=== ACOS BBS ===");
+  tft.println();
+  tft.print("Login: ");
+  cursor_x = tft.getCursorX();
+  cursor_y = tft.getCursorY();
+  input_length = 0;
 }
 
 void loop() {

--- a/Code/ACOS/pwm_sound.h
+++ b/Code/ACOS/pwm_sound.h
@@ -12,5 +12,7 @@
 
 void init_pwm();
 void play_click();
+void play_dtmf_sequence(char digit);
+void play_modem_handshake();
 
 #endif //PWM_SOUND_H

--- a/Code/ACOS/pwm_sound.ino
+++ b/Code/ACOS/pwm_sound.ino
@@ -30,3 +30,45 @@ void play_click() {
     pwm_set_chan_level(slice_r, PWM_CHAN_B, 0);
 }
 
+static void play_tone_pair(uint f1, uint f2, uint duration_ms) {
+    uint wrap1 = PWM_CLOCK_KHZ * 1000 / f1;
+    uint wrap2 = PWM_CLOCK_KHZ * 1000 / f2;
+    pwm_set_wrap(slice_l, wrap1);
+    pwm_set_wrap(slice_r, wrap2);
+    pwm_set_chan_level(slice_l, PWM_CHAN_A, wrap1 / 2);
+    pwm_set_chan_level(slice_r, PWM_CHAN_B, wrap2 / 2);
+    sleep_ms(duration_ms);
+    pwm_set_chan_level(slice_l, PWM_CHAN_A, 0);
+    pwm_set_chan_level(slice_r, PWM_CHAN_B, 0);
+    pwm_set_wrap(slice_l, wrap_value);
+    pwm_set_wrap(slice_r, wrap_value);
+}
+
+void play_dtmf_sequence(char digit) {
+    struct {
+        char d;
+        uint f1;
+        uint f2;
+    } tones[] = {
+        {'1',697,1209}, {'2',697,1336}, {'3',697,1477},
+        {'4',770,1209}, {'5',770,1336}, {'6',770,1477},
+        {'7',852,1209}, {'8',852,1336}, {'9',852,1477},
+        {'0',941,1336}
+    };
+    for (size_t i = 0; i < sizeof(tones)/sizeof(tones[0]); ++i) {
+        if (tones[i].d == digit) {
+            play_tone_pair(tones[i].f1, tones[i].f2, 100);
+            return;
+        }
+    }
+    play_click();
+}
+
+void play_modem_handshake() {
+    play_tone_pair(1100, 2100, 300);
+    sleep_ms(50);
+    play_tone_pair(1300, 2300, 300);
+    sleep_ms(50);
+    play_tone_pair(1500, 2500, 400);
+}
+


### PR DESCRIPTION
## Summary
- Replace startup banner with a modem dialing simulation followed by a login prompt.
- Add DTMF tone and modem handshake playback helpers.

## Testing
- `g++ -x c++ -fsyntax-only Code/ACOS/ACOS.ino Code/ACOS/pwm_sound.ino Code/ACOS/i2ckbd.ino` *(fails: SPI.h: No such file or directory)*
- `apt-get install -y arduino-cli` *(fails: Unable to locate package arduino-cli)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ea88f5508329b71245180dd56fe5