### PR TITLE
Add tone routines with DTMF and modem handshake playback

### DIFF
--- a/Code/ACOS/pwm_sound.h
+++ b/Code/ACOS/pwm_sound.h
@@ -12,7 +12,8 @@
 
 void init_pwm();
 void play_click();
-void play_dtmf_sequence(char digit);
+void play_tone(uint freq_hz, uint duration_ms);
+void play_dtmf_sequence(const char *digits);
 void play_modem_handshake();
 
 #endif //PWM_SOUND_H

--- a/Code/ACOS/pwm_sound.ino
+++ b/Code/ACOS/pwm_sound.ino
@@ -15,60 +15,72 @@ void init_pwm() {
     pwm_config_set_clkdiv(&config, 125.0f);
     pwm_config_set_wrap(&config, wrap_value);
 
-    pwm_init(slice_l, &config, true);
-    pwm_init(slice_r, &config, true);
+    pwm_init(slice_l, &config, false);
+    pwm_init(slice_r, &config, false);
 
     pwm_set_chan_level(slice_l, PWM_CHAN_A, 0);
     pwm_set_chan_level(slice_r, PWM_CHAN_B, 0);
+
+    pwm_set_enabled(slice_l, false);
+    pwm_set_enabled(slice_r, false);
+}
+ 
+void play_click() {
+    play_tone(1000, 10);
 }
 
-void play_click() {
+void play_tone(uint freq_hz, uint duration_ms) {
+    float clkdiv = (float)PWM_CLOCK_KHZ * 1000 / ((float)freq_hz * wrap_value);
+    pwm_set_clkdiv(slice_l, clkdiv);
+    pwm_set_clkdiv(slice_r, clkdiv);
+    pwm_set_enabled(slice_l, true);
+    pwm_set_enabled(slice_r, true);
     pwm_set_chan_level(slice_l, PWM_CHAN_A, wrap_value / 2);
     pwm_set_chan_level(slice_r, PWM_CHAN_B, wrap_value / 2);
-    sleep_ms(10);
-    pwm_set_chan_level(slice_l, PWM_CHAN_A, 0);
-    pwm_set_chan_level(slice_r, PWM_CHAN_B, 0);
-}
-
-static void play_tone_pair(uint f1, uint f2, uint duration_ms) {
-    uint wrap1 = PWM_CLOCK_KHZ * 1000 / f1;
-    uint wrap2 = PWM_CLOCK_KHZ * 1000 / f2;
-    pwm_set_wrap(slice_l, wrap1);
-    pwm_set_wrap(slice_r, wrap2);
-    pwm_set_chan_level(slice_l, PWM_CHAN_A, wrap1 / 2);
-    pwm_set_chan_level(slice_r, PWM_CHAN_B, wrap2 / 2);
     sleep_ms(duration_ms);
     pwm_set_chan_level(slice_l, PWM_CHAN_A, 0);
     pwm_set_chan_level(slice_r, PWM_CHAN_B, 0);
-    pwm_set_wrap(slice_l, wrap_value);
-    pwm_set_wrap(slice_r, wrap_value);
+    pwm_set_enabled(slice_l, false);
+    pwm_set_enabled(slice_r, false);
 }
 
-void play_dtmf_sequence(char digit) {
+void play_dtmf_sequence(const char *digits) {
     struct {
         char d;
         uint f1;
         uint f2;
     } tones[] = {
-        {'1',697,1209}, {'2',697,1336}, {'3',697,1477},
-        {'4',770,1209}, {'5',770,1336}, {'6',770,1477},
-        {'7',852,1209}, {'8',852,1336}, {'9',852,1477},
-        {'0',941,1336}
+        {'1',697,1209}, {'2',697,1336}, {'3',697,1477}, {'A',697,1633},
+        {'4',770,1209}, {'5',770,1336}, {'6',770,1477}, {'B',770,1633},
+        {'7',852,1209}, {'8',852,1336}, {'9',852,1477}, {'C',852,1633},
+        {'*',941,1209}, {'0',941,1336}, {'#',941,1477}, {'D',941,1633}
     };
-    for (size_t i = 0; i < sizeof(tones)/sizeof(tones[0]); ++i) {
-        if (tones[i].d == digit) {
-            play_tone_pair(tones[i].f1, tones[i].f2, 100);
-            return;
+
+    for (const char *p = digits; p && *p; ++p) {
+        bool found = false;
+        for (size_t i = 0; i < sizeof(tones)/sizeof(tones[0]); ++i) {
+            if (tones[i].d == *p) {
+                play_tone(tones[i].f1, 60);
+                play_tone(tones[i].f2, 60);
+                sleep_ms(40);
+                found = true;
+                break;
+            }
+        }
+        if (!found) {
+            play_click();
         }
     }
-    play_click();
 }
 
 void play_modem_handshake() {
-    play_tone_pair(1100, 2100, 300);
+    play_tone(1100, 300);
+    play_tone(2100, 300);
     sleep_ms(50);
-    play_tone_pair(1300, 2300, 300);
+    play_tone(1300, 300);
+    play_tone(2300, 300);
     sleep_ms(50);
-    play_tone_pair(1500, 2500, 400);
+    play_tone(1500, 400);
+    play_tone(2500, 400);
 }
 


### PR DESCRIPTION
## Summary
- Provide play_tone() for simple PWM tone generation
- Add DTMF digit sequence and modem-handshake playback helpers
- Ensure PWM init starts muted and unify click tone on play_tone

## Testing
- `g++ -x c++ -c Code/ACOS/pwm_sound.ino -I. -std=c++17` *(fails: pico/stdlib.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ee112f908329bf50a0efeb6fe6ff