### PR TITLE
Fix DTMF function call in ACOS

### DIFF
--- a/Code/ACOS/ACOS.ino
+++ b/Code/ACOS/ACOS.ino
@@ -83,7 +83,8 @@ void simulate_modem_dial() {
     tft.setCursor(tft.getCursorX(), tft.getCursorY());
     tft.print(*p);
     if (*p >= '0' && *p <= '9') {
-      play_dtmf_sequence(*p);
+      char digit[2] = {*p, '\0'};
+      play_dtmf_sequence(digit);
     }
     sleep_ms(150);
   }


### PR DESCRIPTION
## Summary
- Ensure DTMF tone playback accepts a char digit by creating a temporary two-character buffer before calling `play_dtmf_sequence`

## Testing
- `g++ -x c++ -fsyntax-only Code/ACOS/ACOS.ino` *(fails: SPI.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a7f291822483298bd1d8eea4be2768